### PR TITLE
Implement server message validation for ZodNamespace

### DIFF
--- a/packages/core/test/zodNamespace.test.ts
+++ b/packages/core/test/zodNamespace.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { ZodNamespace } from "../src/v3/zodNamespace.js";
+import type { Server } from "socket.io";
+import { z } from "zod";
+
+const createStubServer = (): Server => {
+  const namespace = {
+    use: () => namespace,
+    on: () => namespace,
+    emit: () => {},
+    fetchSockets: async () => [],
+  } as any;
+  return { of: () => namespace } as any;
+};
+
+describe("ZodNamespace", () => {
+  it("throws when serverMessages include callbacks", () => {
+    const io = createStubServer();
+
+    const clientMessages = {} as const;
+    const serverMessages = {
+      TEST: {
+        message: z.object({ version: z.literal("v1").default("v1") }),
+        callback: z.void(),
+      },
+    } as const;
+
+    expect(
+      () =>
+        new ZodNamespace({
+          io,
+          name: "test",
+          clientMessages,
+          serverMessages,
+        })
+    ).toThrowError(/callbacks are not supported/);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure `ZodNamespace` options cannot include callback schemas
- throw an error when server messages define callbacks
- add unit test for the new validation

## Testing
- `pnpm test --filter core` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f61a9a7788324b6c209944a6c61bb