### PR TITLE
Improve payload parsing for message handler

### DIFF
--- a/packages/core/src/v3/zodMessageHandler.test.ts
+++ b/packages/core/src/v3/zodMessageHandler.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi } from "vitest";
+import { EventEmitter } from "node:events";
+import { ZodMessageHandler } from "./zodMessageHandler.js";
+import { z } from "zod";
+
+describe("ZodMessageHandler.registerHandlers", () => {
+  const schema = { TEST: z.object({ foo: z.string() }) } as const;
+
+  it("handles messages with an explicit payload field", async () => {
+    const handler = vi.fn(async (payload: { foo: string }) => payload);
+    const messageHandler = new ZodMessageHandler({ schema, messages: { TEST: handler } });
+    const emitter = new EventEmitter();
+    messageHandler.registerHandlers(emitter);
+
+    const ack = await new Promise((resolve) => {
+      emitter.emit("TEST", { payload: { foo: "bar" }, version: "v1" }, resolve);
+    });
+
+    expect(handler).toHaveBeenCalledWith({ foo: "bar" });
+    expect(ack).toEqual({ foo: "bar" });
+  });
+
+  it("handles messages without a payload field", async () => {
+    const handler = vi.fn(async (payload: { foo: string }) => payload);
+    const messageHandler = new ZodMessageHandler({ schema, messages: { TEST: handler } });
+    const emitter = new EventEmitter();
+    messageHandler.registerHandlers(emitter);
+
+    const ack = await new Promise((resolve) => {
+      emitter.emit("TEST", { foo: "baz", version: "v1" }, resolve);
+    });
+
+    expect(handler).toHaveBeenCalledWith({ foo: "baz" });
+    expect(ack).toEqual({ foo: "baz" });
+  });
+});


### PR DESCRIPTION
## Summary
- parse incoming messages with runtime zod checks instead of relying on `'payload' in` heuristic
- add unit tests covering both forms of incoming messages

## Testing
- `pnpm run test --filter "@trigger.dev/core"` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f620c452c8324b2412d2059b047b1